### PR TITLE
Add skill for content bank type plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ MoMoPDA is a collection of Agent Skills for developing Moodle plugins. Following
 ## Available Skills
 
 | Skill | Description |
-|-------|-------------|
+| ----- | ----------- |
 | `moodle-core` | Core Moodle 5.x development: coding standards, security, JavaScript, CI validation |
 | `moodle-activity` | Activity module plugins (mod_*) |
 | `moodle-block` | Block plugins (block_*) |
@@ -15,6 +15,7 @@ MoMoPDA is a collection of Agent Skills for developing Moodle plugins. Following
 | `moodle-filter` | Filter plugins (filter_*) |
 | `moodle-tiny` | TinyMCE editor plugins (tiny_*) |
 | `moodle-report` | Report plugins (report_*) |
+| `moodle-contenttype` | Content bank type plugins (contenttype_*) |
 | `moodle-local` | Local plugins (local_*) |
 
 ## Installation
@@ -41,7 +42,7 @@ Copy the desired skill folders to your tool's skill directory, or reference them
 
 When working on a Moodle plugin, activate the relevant skills:
 
-```
+```text
 # For a block plugin
 /skill moodle-core
 /skill moodle-block
@@ -68,7 +69,7 @@ Or place Moodle at `../moodle` relative to your plugin directory.
 
 ## Directory Structure
 
-```
+```text
 skills/
 ├── moodle-core/
 │   ├── SKILL.md                # Core development practices
@@ -110,8 +111,8 @@ See [Moodle Plugin CI](https://moodlehq.github.io/moodle-plugin-ci/) for install
 ### Creating a New Plugin
 
 > I want to create a block plugin that displays student progress charts on the course page.
-
 > Help me create a question type plugin for mathematical expression input with LaTeX rendering.
+> Help me create a content bank type plugin that lets teachers upload and preview SVG diagrams in the content bank.
 
 ### Bug Fixing
 
@@ -120,7 +121,6 @@ See [Moodle Plugin CI](https://moodlehq.github.io/moodle-plugin-ci/) for install
 ### Complex Projects
 
 > I want to create a question bank (qbank) plugin which adds bulk edit functionality. It should use the AI generation purpose from ../moodle-local_ai_manager and the architecture of ../moodle-qbank_questiongen to: 1) bulk select questions to modify, 2) add a modification prompt, 3) generate new versions according to the prompt, 4) add a prefix to distinguish new questions.
-
 > This repo has a modular prompt system for developing Moodle plugins. I need to develop a local plugin that adds User overrides to all the quizzes on the course area. MVP: add custom quiz time limit for a user.
 
 ## Tips for Best Results

--- a/skills/moodle-contenttype/SKILL.md
+++ b/skills/moodle-contenttype/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: moodle-contenttype
+description: Development guide for Moodle content bank type plugins (contenttype_*). Use when creating reusable content types for the content bank with upload, view, edit, download, and copy support.
+compatibility: Requires Moodle 5.x development environment
+metadata:
+  author: sarjona
+  version: "1.0.0"
+---
+
+# Moodle content bank type development
+
+Content bank type plugins (contenttype_*) let teachers and designers upload and reuse specific content formats across Moodle contexts (system, category, and course).
+
+## Environment Setup
+
+This skill expects:
+- Plugin code in `public/contentbank/contenttype/yourtype`
+- Moodle source in the current workspace
+- A Moodle test site with Content bank enabled
+
+## Recommended Skills
+
+For coding standards, security, and CI checks, also activate the `moodle-core` skill.
+
+## Plugin Structure
+
+```
+contentbank/contenttype/yourtype/
+|- classes/
+|  |- contenttype.php          # Type behavior (features, extensions, view/edit/copy rules)
+|  |- content.php              # Content instance behavior (file import, view permission)
+|  |- privacy/
+|  |  |- provider.php          # Usually null provider
+|  |- form/                    # Optional, for custom editors
+|  |  |- editor.php
+|- db/
+|  |- access.php               # Plugin capabilities
+|- lang/en/
+|  |- contenttype_yourtype.php # Plugin strings
+|- tests/
+|  |- *_test.php               # PHPUnit tests
+|- pix/                        # Optional icons
+|- version.php                 # Plugin metadata
+```
+
+## Core Implementation Flow
+
+1. Define plugin metadata in `version.php`.
+2. Implement `\\contenttype_yourtype\\contenttype` extending `\\core_contentbank\\contenttype`.
+3. Implement `\\contenttype_yourtype\\content` extending `\\core_contentbank\\content`.
+4. Add capabilities in `db/access.php` and strings in `lang/en/contenttype_yourtype.php`.
+5. Add PHPUnit tests for create/upload/view/edit/delete/copy behavior.
+6. Add Behat coverage for UI workflows in Content bank.
+
+## Minimal `contenttype` Contract
+
+In `classes/contenttype.php` implement at least:
+- `get_implemented_features()` returning supported features.
+- `get_manageable_extensions()` returning supported file extensions.
+
+Typical supported features:
+- `self::CAN_UPLOAD`
+- `self::CAN_EDIT`
+- `self::CAN_DOWNLOAD`
+- `self::CAN_COPY`
+
+Also commonly implemented:
+- `get_contenttype_types()` for dropdown type variants.
+- `get_icon()` for content-specific icon rendering.
+- `get_view_content()` to render the visualizer output.
+- `delete_content()` if plugin-specific cleanup is required before `parent::delete_content()`.
+
+## Minimal `content` Contract
+
+In `classes/content.php` you typically customize:
+- `is_view_allowed()` to enforce type-specific visibility rules.
+- `import_file(\\stored_file $file)` to validate and normalize uploaded files before calling parent logic.
+
+Use file API conventions from core Content bank:
+- Component: `contentbank`
+- File area: `public`
+- Item id: content id
+
+## Capabilities and Access
+
+Define plugin capabilities in `db/access.php` like:
+- `contenttype/yourtype:access`
+- `contenttype/yourtype:upload`
+- Optional type-specific capabilities (for example, editor usage)
+
+Use context-aware checks in type/content methods and avoid system-level assumptions when the content lives in course/category contexts.
+
+## Editor Integration (Optional)
+
+If your type has an authoring UI:
+- Add `classes/form/editor.php` extending `\\core_contentbank\\form\\edit_content`.
+- Support both create and edit flow.
+- Save custom fields through `\\core_contentbank\\customfield\\content_handler` when needed.
+
+## Testing Strategy
+
+### PHPUnit (required)
+
+Cover these scenarios:
+- Feature availability and capability checks per role/context.
+- Upload/import validation success and failure paths.
+- View permission behavior (`is_view_allowed`) for different users.
+- Deletion cleanup (DB records + file removal + plugin-specific side effects).
+- Download/copy behavior if supported.
+
+Use content bank generators where possible:
+- `core_contentbank` generator for creating test content quickly.
+
+### Behat (required)
+
+Add scenarios for:
+- Content creation/upload from Content bank UI.
+- Access restrictions for teachers/students/admins.
+- Edit/copy/download controls visibility.
+- Context navigation (system/category/course).
+
+## Quality Checklist
+
+Before submitting:
+- `phpcs --standard=moodle-extra` passes for plugin files.
+- PHPUnit tests pass.
+- No direct superglobal access (`$_GET`, `$_POST`) in plugin logic.
+- All user-facing strings are in language files.
+- Capability checks are context-specific and explicit.
+
+## Common Pitfalls
+
+- Declaring extensions but not enabling `CAN_UPLOAD`.
+- Forgetting to clean plugin-side data in overridden `delete_content()`.
+- Returning content objects without validating ownership or context permissions.
+- Missing language strings for new capabilities.
+- Assuming one context level only (Content bank supports multiple context scopes).
+
+## Reference Implementations
+
+Use these implementations as concrete guides:
+- Core H5P content type: `public/contentbank/contenttype/h5p/`
+- Content bank base APIs: `public/contentbank/classes/contenttype.php`, `public/contentbank/classes/content.php`
+
+External examples:
+- https://github.com/ferranrecio/moodle-contenttype_html
+- https://github.com/moodle/moodle/tree/main/public/contentbank/contenttype/h5p
+
+Official docs:
+- https://docs.moodle.org/dev/Content_bank_content_types
+
+For deeper implementation patterns and anti-patterns, see [Content Bank Type Patterns](references/patterns.md).

--- a/skills/moodle-contenttype/references/patterns.md
+++ b/skills/moodle-contenttype/references/patterns.md
@@ -1,0 +1,55 @@
+# Content Bank Type Patterns and Anti-Patterns
+
+## Good Patterns
+
+### 1) Keep type and content responsibilities separated
+
+- `contenttype` class: declares features, capabilities, rendering, and type-level behavior.
+- `content` class: enforces instance-level checks and file import behavior.
+
+### 2) Validate uploads before persisting side effects
+
+In `import_file(...)`, validate file format and reject invalid files with Moodle exceptions.
+
+### 3) Reuse core cleanup flow
+
+If you override `delete_content(...)`, do plugin-specific cleanup first, then call `parent::delete_content(...)`.
+
+### 4) Test by role and context
+
+Always test permissions in system, category, and course contexts because Content bank visibility differs by context and role.
+
+### 5) Use core generators in tests
+
+Prefer `core_contentbank` test generators for fast, consistent setup and less test boilerplate.
+
+## Anti-Patterns
+
+### 1) Hardcoding one context scope
+
+Do not assume all content is system-level; course and category contexts are common.
+
+### 2) Missing capability checks in custom actions
+
+If you add custom edit/copy/delete behavior, capability checks must happen before action execution.
+
+### 3) Skipping language strings
+
+Do not hardcode visible text in PHP; add plugin strings in `lang/en/contenttype_yourtype.php`.
+
+### 4) Incomplete feature declarations
+
+If your plugin supports download/copy/edit, return the feature in `get_implemented_features()`; otherwise the UI and APIs may behave unexpectedly.
+
+### 5) Tests that only assert happy path
+
+Include invalid uploads, disabled capabilities, and ownership mismatch scenarios.
+
+## Practical Review Checklist
+
+- Class names match plugin frankenstyle (`contenttype_yourtype`).
+- `version.php` component is correct.
+- `get_manageable_extensions()` aligns with actual validation logic.
+- `is_view_allowed()` does not leak inaccessible content.
+- Deletion removes file and content record, and any plugin-side metadata.
+- PHPUnit covers both permitted and denied actions.


### PR DESCRIPTION
I have created a skill for the content bank content type plugins. Amaia and I will be giving a presentation at the MoodleMoot Euskadi, and we wanted to create a simple AI plugin using this assistant :-)

This pull request is based on the `feature/agent-skills-conversion branch` :-)